### PR TITLE
Fix Typo in entries controller

### DIFF
--- a/app/controllers/api/v1/entries_controller.rb
+++ b/app/controllers/api/v1/entries_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::EntriesController < ApiController
-  BASIC_FIELDS = [:title, :type, :abstract, :document_number, :html_url, :pdf_url, :public_inspection_pdf_url, :publication_date, :agenices, :excerpts]
+  BASIC_FIELDS = [:title, :type, :abstract, :document_number, :html_url, :pdf_url, :public_inspection_pdf_url, :publication_date, :agencies, :excerpts]
 
   def index
     respond_to do |wants|


### PR DESCRIPTION
This fixes an error when calling http://api.federalregister.gov/v1/articles.json.  Would it be possible to get this fix live today?
